### PR TITLE
Add click event handler

### DIFF
--- a/Gallery.svelte
+++ b/Gallery.svelte
@@ -1,6 +1,7 @@
 <script>
-    import { onMount } from 'svelte';
+    import { onMount, createEventDispatcher } from 'svelte';
     import { tick } from 'svelte';
+	const dispatch = createEventDispatcher();
     
     export let gap = 10;
     export let maxColumnWidth = 250;
@@ -15,6 +16,12 @@
     $: galleryStyle = `grid-template-columns: repeat(${columnCount}, 1fr); --gap: ${gap}px`;
     
     onMount(Draw);
+
+    function handleClick(e) {
+		dispatch('click', {
+			url: e.target.src
+		});
+	}
 
     async function Draw() {
         
@@ -42,7 +49,7 @@
     {#each columns as column}
     <div class="column">
         {#each column as url}
-        <img src={url} alt="" />
+        <img src={url} alt="" on:click={handleClick}/>
         {/each}
     </div>
     {/each}

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ A Masonry-Like Image Container for Svelte
 
 [See On REPL][repl]
 
-| Traditional | svelte-image-gallery |
-| ----------- | -------------------- |
-| ![traditional][ss1] | ![svelte-image-gallery][ss2] |
-| Made responsive via media queries or [minmax/autofit][minmax] | Responsive out of the box |
+| Traditional                                                   | svelte-image-gallery         |
+| ------------------------------------------------------------- | ---------------------------- |
+| ![traditional][ss1]                                           | ![svelte-image-gallery][ss2] |
+| Made responsive via media queries or [minmax/autofit][minmax] | Responsive out of the box    |
 
 [ss1]: https://i.imgur.com/rTSftEw.jpg
 [ss2]: https://i.imgur.com/CpgVaWm.jpg
@@ -17,6 +17,7 @@ A Masonry-Like Image Container for Svelte
 [repl]: https://svelte.dev/repl/29b37509123b4a4bac808531f39d7d9e?version=3.24.1
 
 ### Installation
+
 ```sh
 npm install --save-dev svelte-image-gallery
 ```
@@ -26,9 +27,13 @@ npm install --save-dev svelte-image-gallery
 ```svelte
 <script>
 	import Gallery from 'svelte-image-gallery'
+
+	function handleClick(e) {
+		console.log(e.detail.url)
+	}
 </script>
 
-<Gallery>
+<Gallery on:click={handleClick}>
 	<img src="..." />
 	<img src="..." />
 	...
@@ -37,15 +42,18 @@ npm install --save-dev svelte-image-gallery
 
 ### Running Locally
 
-* Clone the repository
-* Open `example` folder in terminal
-* Run `npm i`, then `npm run dev`
+-   Clone the repository
+-   Open `example` folder in terminal
+-   Run `npm i`, then `npm run dev`
 
 ### Parameters
 
 | Parameter      | Default | Description            | Unit |
-| -------------- | ------- | -----------            | ---- |
+| -------------- | ------- | ---------------------- | ---- |
 | gap            | 10      | Grid Gap Between Items | px   |
 | maxColumnWidth | 250     | Maximum Column Width   | px   |
+
+To access the image url on click, use the `on:click` directive in the Gallery component.
+
 
 > Created By [Berkin AKKAYA](https://berkinakkaya.github.io)

--- a/example/App.svelte
+++ b/example/App.svelte
@@ -1,8 +1,12 @@
 <script>
     import Gallery from '../Gallery.svelte';
+
+	function handleClick(e) {
+		console.log(e.detail.url)
+	}
 </script>
 
-<Gallery gap={15} maxColumnWidth={250}>
+<Gallery gap={15} maxColumnWidth={250} on:click={handleClick}>
 	<img src="https://via.placeholder.com/210x170/100" alt="">
 	<img src="https://via.placeholder.com/180x200/100" alt="">
 	<img src="https://via.placeholder.com/200x210/100" alt="">


### PR DESCRIPTION
At present, the Gallery strips images of their attributes, including their event handlers. As a minimal fix, this pull request adds a click handler to each `img` that returns its `src`. 