### PR TITLE
Add lazy loading, image hover, classes, and update handle click to pass in alt, loading, and classname

### DIFF
--- a/Gallery.svelte
+++ b/Gallery.svelte
@@ -1,11 +1,13 @@
 <script>
-    import { onMount, createEventDispatcher } from 'svelte';
-    import { tick } from 'svelte';
+    import { onMount, createEventDispatcher } from "svelte";
+    import { tick } from "svelte";
 
     export let gap = 10;
     export let maxColumnWidth = 250;
+    export let hover = false;
+    export let loading;
 
-	const dispatch = createEventDispatcher();
+    const dispatch = createEventDispatcher();
 
     let slotHolder = null;
     let columns = [];
@@ -18,46 +20,86 @@
 
     onMount(Draw);
 
-    function HandleClick (e) {
-        dispatch('click', { src: e.target.src });
-	}
+    function HandleClick(e) {
+        dispatch("click", { src: e.target.src, alt: e.target.alt, loading: e.target.loading, class: e.target.className });
+    }
 
     async function Draw() {
         await tick();
 
-        if (!slotHolder) { return }
+        if (!slotHolder) {
+            return;
+        }
 
-        const images = Array.from(slotHolder.childNodes).filter(child => child.tagName === "IMG");
+        const images = Array.from(slotHolder.childNodes).filter(
+            (child) => child.tagName === "IMG"
+        );
         columns = [];
 
         // Fill the columns with image URLs
-        for (let i=0; i<images.length; i++) {
+        for (let i = 0; i < images.length; i++) {
             const idx = i % columnCount;
-            columns[idx] = [...columns[idx] || [], images[i].src];
+            columns[idx] = [
+                ...(columns[idx] || []),
+                { src: images[i].src, alt: images[i].alt },
+            ];
         }
     }
 </script>
 
-<div id="slotHolder" bind:this={slotHolder} on:DOMNodeInserted={Draw} on:DOMNodeRemoved={Draw}>
-    <slot></slot>
+<div
+    id="slotHolder"
+    bind:this={slotHolder}
+    on:DOMNodeInserted={Draw}
+    on:DOMNodeRemoved={Draw}
+>
+    <slot />
 </div>
 
 {#if columns}
-<div id="gallery" bind:clientWidth={galleryWidth} style={galleryStyle}>
-    {#each columns as column}
-    <div class="column">
-        {#each column as url}
-        <img src={url} alt="" on:click={HandleClick}/>
+    <div id="gallery" bind:clientWidth={galleryWidth} style={galleryStyle}>
+        {#each columns as column}
+            <div class="column">
+                {#each column as img}
+                    <img
+                        src={img.src}
+                        alt={img.alt}
+                        on:click={HandleClick}
+                        class={hover === true ? "img-hover" : ""}
+                        loading={loading}
+                    />
+                {/each}
+            </div>
         {/each}
     </div>
-    {/each}
-</div>
 {/if}
 
 <style>
-    #slotHolder { display: none }
-    #gallery { width: 100%; display: grid; gap: var(--gap) }
-    #gallery .column { display: flex; flex-direction: column }
-    #gallery .column * { width: 100%; margin-top: var(--gap) }
-    #gallery .column *:nth-child(1) { margin-top: 0 }
+    #slotHolder {
+        display: none;
+    }
+    #gallery {
+        width: 100%;
+        display: grid;
+        gap: var(--gap);
+    }
+    #gallery .column {
+        display: flex;
+        flex-direction: column;
+    }
+    #gallery .column * {
+        width: 100%;
+        margin-top: var(--gap);
+    }
+    #gallery .column *:nth-child(1) {
+        margin-top: 0;
+    }
+    .img-hover {
+        opacity: 0.9;
+        transition: all 0.2s;
+    }
+    .img-hover:hover {
+        opacity: 1;
+        transform: scale(1.05);
+    }
 </style>

--- a/Gallery.svelte
+++ b/Gallery.svelte
@@ -41,7 +41,7 @@
             const idx = i % columnCount;
             columns[idx] = [
                 ...(columns[idx] || []),
-                { src: images[i].src, alt: images[i].alt },
+                { src: images[i].src, alt: images[i].alt, class: images[i].className },
             ];
         }
     }
@@ -65,7 +65,7 @@
                         src={img.src}
                         alt={img.alt}
                         on:click={HandleClick}
-                        class={hover === true ? "img-hover" : ""}
+                        class="{hover === true ? "img-hover" : ""} {img.class}"
                         loading={loading}
                     />
                 {/each}

--- a/example/App.svelte
+++ b/example/App.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <Gallery gap={15} maxColumnWidth={250} on:click={HandleClick} hover={true} loading="lazy">
-	<img src="https://via.placeholder.com/210x170/100" alt="210x170">
+	<img src="https://via.placeholder.com/210x170/100" alt="210x170" class="Hi">
 	<img src="https://via.placeholder.com/180x200/100" alt="180x200">
 	<img src="https://via.placeholder.com/200x210/100" alt="200x210">
 	<img src="https://via.placeholder.com/140x250/100" alt="140x250">

--- a/example/App.svelte
+++ b/example/App.svelte
@@ -17,10 +17,10 @@
 	<img src="https://via.placeholder.com/180x150/100" alt="180x150">
 	<img src="https://via.placeholder.com/210x210/100" alt="210x210">
 	<img src="https://via.placeholder.com/200x200/100" alt="200x200">
-	<img src="https://via.placeholder.com/200x200/100" alt="200x200">
+	<img src="https://via.placeholder.com/220x200/100" alt="220x200">
 	<img src="https://via.placeholder.com/180x310/100" alt="180x310">
 	<img src="https://via.placeholder.com/210x210/100" alt="210x210">
 	<img src="https://via.placeholder.com/200x280/100" alt="200x280">
 	<img src="https://via.placeholder.com/210x350/100" alt="210x350">
-	<img src="https://via.placeholder.com/210x350/100" alt="210x350">
+	<img src="https://via.placeholder.com/180x270/100" alt="180x270">
 </Gallery>

--- a/example/App.svelte
+++ b/example/App.svelte
@@ -1,26 +1,26 @@
 <script>
-	import Gallery from "svelte-image-gallery";
+	import Gallery from "../Gallery.svelte";
 
 	function HandleClick(e) {
-		console.log(e.detail.src)
+		console.log(`src: ${e.detail.src}, alt: ${e.detail.alt}, loading: ${e.detail.loading}, class: ${e.detail.class}`)
 	}
 </script>
 
-<Gallery gap={15} maxColumnWidth={250} on:click={HandleClick}>
-	<img src="https://via.placeholder.com/210x170/100" alt="">
-	<img src="https://via.placeholder.com/180x200/100" alt="">
-	<img src="https://via.placeholder.com/200x210/100" alt="">
-	<img src="https://via.placeholder.com/140x250/100" alt="">
-	<img src="https://via.placeholder.com/250x300/100" alt="">
-	<img src="https://via.placeholder.com/280x200/100" alt="">
-	<img src="https://via.placeholder.com/220x180/100" alt="">
-	<img src="https://via.placeholder.com/180x150/100" alt="">
-	<img src="https://via.placeholder.com/210x210/100" alt="">
-	<img src="https://via.placeholder.com/200x200/100" alt="">
-	<img src="https://via.placeholder.com/220x200/100" alt="">
-	<img src="https://via.placeholder.com/180x310/100" alt="">
-	<img src="https://via.placeholder.com/210x210/100" alt="">
-	<img src="https://via.placeholder.com/200x280/100" alt="">
-	<img src="https://via.placeholder.com/210x350/100" alt="">
-	<img src="https://via.placeholder.com/180x270/100" alt="">
+<Gallery gap={15} maxColumnWidth={250} on:click={HandleClick} hover={true} loading="lazy">
+	<img src="https://via.placeholder.com/210x170/100" alt="210x170">
+	<img src="https://via.placeholder.com/180x200/100" alt="180x200">
+	<img src="https://via.placeholder.com/200x210/100" alt="200x210">
+	<img src="https://via.placeholder.com/140x250/100" alt="140x250">
+	<img src="https://via.placeholder.com/250x300/100" alt="250x300">
+	<img src="https://via.placeholder.com/280x200/100" alt="280x200">
+	<img src="https://via.placeholder.com/220x180/100" alt="220x180">
+	<img src="https://via.placeholder.com/180x150/100" alt="180x150">
+	<img src="https://via.placeholder.com/210x210/100" alt="210x210">
+	<img src="https://via.placeholder.com/200x200/100" alt="200x200">
+	<img src="https://via.placeholder.com/200x200/100" alt="200x200">
+	<img src="https://via.placeholder.com/180x310/100" alt="180x310">
+	<img src="https://via.placeholder.com/210x210/100" alt="210x210">
+	<img src="https://via.placeholder.com/200x280/100" alt="200x280">
+	<img src="https://via.placeholder.com/210x350/100" alt="210x350">
+	<img src="https://via.placeholder.com/210x350/100" alt="210x350">
 </Gallery>


### PR DESCRIPTION
When I have used the packages, these are a few improvements that I have made. The opacity for .img-hover could potentially be improved and maybe it should just be a size transform. I like it with opacity when having photos in the gallery but it looks a little weird with the black placeholder images in the example. Also, I didn't do this but I'd appreciate if a prettier file could be added to the example.