### PR TITLE
Updating package.json to fix vite crashes when SvelteKit is updated to +1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
 	"version": "1.7.0",
 	"description": "A Masonry-Like Image Container for Svelte",
 	"main": "index.mjs",
+	"module": "index.mjs",
+	"svelte": "index.mjs",
 	"scripts": {},
 	"keywords": [],
 	"author": "Berkin AKKAYA <berkin_akkaya@hotmail.com>",


### PR DESCRIPTION
Vite expects to see the svelte and module properties in the package.json, so by adding them and pointing them to the root index file that starts the package, this appeases Vite and the app is able to use the package as intended. 

Fixes [Issue #12](https://github.com/BerkinAKKAYA/svelte-image-gallery/issues/12)